### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-    "name":             "grunt-model-settings",
-    "description":      "Grunt plugin for loading and merge settings from grunt config file",
-    "version":          "0.0.2",
-    "homepage":         "https://github.com/el-fuego/grunt-model-settings.git",
-    "author":           {
-        "name":  "Yuriy Pulyaev",
+    "name": "grunt-model-settings",
+    "description": "Grunt plugin for loading and merge settings from grunt config file",
+    "version": "0.0.2",
+    "homepage": "https://github.com/el-fuego/grunt-model-settings.git",
+    "author": {
+        "name": "Yuriy Pulyaev",
         "email": "watt87@mail.ru"
     },
-    "repository":       {
+    "repository": {
         "type": "git",
-        "url":  "https://github.com/el-fuego/grunt-model-settings.git"
+        "url": "https://github.com/el-fuego/grunt-model-settings.git"
     },
-    "bugs":             {
+    "bugs": {
         "url": "https://github.com/el-fuego/grunt-model-settings.git/issues"
     },
-    "licenses":         [
+    "licenses": [
         {
             "type": "MIT",
-            "url":  "https://github.com/el-fuego/grunt-model-settings/blob/master/LICENSE.md"
+            "url": "https://github.com/el-fuego/grunt-model-settings/blob/master/LICENSE.md"
         }
     ],
-    "main":             "Gruntfile.js",
-    "engines":          {
+    "main": "Gruntfile.js",
+    "engines": {
         "node": ">= 0.8.0"
     },
-    "scripts":          {
+    "scripts": {
         "test": "grunt test"
     },
-    "devDependencies":  {
-        "grunt-contrib-jshint":   "~0.1.1",
+    "devDependencies": {
+        "grunt-contrib-jshint": "~0.1.1",
         "grunt-contrib-nodeunit": "~0.1.2",
-        "grunt-jsbeautifier":     "~0.2.2",
-        "grunt":                  "~0.4.1"
-    },
-    "peerDependencies": {
+        "grunt-jsbeautifier": "~0.2.2",
         "grunt": "~0.4.1"
     },
-    "keywords":         [
+    "peerDependencies": {
+        "grunt": ">=0.4.0"
+    },
+    "keywords": [
         "gruntplugin",
         "local",
         "settings",


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
